### PR TITLE
Add fn:date alias and tests

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -85,6 +85,8 @@ var (
 		symbols.NumberToString:  symbols.NewFunType(ast.StringBound /* <= */, ast.NumberBound),
 		symbols.Float64ToString: symbols.NewFunType(ast.StringBound /* <= */, ast.Float64Bound),
 		symbols.NameToString:    symbols.NewFunType(ast.StringBound /* <= */, ast.NameBound),
+		symbols.Date:            symbols.NewFunType(ast.DateBound /* <= */, ast.StringBound),
+		symbols.DateParts:       symbols.NewFunType(ast.DateBound /* <= */, ast.NumberBound, ast.NumberBound, ast.NumberBound),
 		symbols.DateFromString:  symbols.NewFunType(ast.DateBound /* <= */, ast.StringBound),
 		symbols.DateToString:    symbols.NewFunType(ast.StringBound /* <= */, ast.DateBound),
 		symbols.DateFromParts:   symbols.NewFunType(ast.DateBound /* <= */, ast.NumberBound, ast.NumberBound, ast.NumberBound),

--- a/docs/spec_builtin_operations.md
+++ b/docs/spec_builtin_operations.md
@@ -38,12 +38,12 @@ Mangle provides helpers for working with `/date` constants.  All dates are
 expressed in ISO-8601 calendar form (YYYY-MM-DD) and represent a calendar day in
 UTC without a time-of-day component.
 
-- `fn:date:from_string(String)` parses an ISO-8601 date string and returns a
-  `/date` value.  Invalid strings (wrong format or impossible dates) produce a
-  runtime error.
-- `fn:date:from_parts(Year, Month, Day)` constructs a date from numeric parts.
-  Each argument must be a number; the function validates that the combination is
-  a real calendar date.
+- `fn:date(String)` (alias `fn:date:from_string(String)`) parses an ISO-8601
+  date string and returns a `/date` value.  Invalid strings (wrong format or
+  impossible dates) produce a runtime error.
+- `fn:date(Year, Month, Day)` (alias `fn:date:from_parts(Year, Month, Day)`)
+  constructs a date from numeric parts.  Each argument must be a number; the
+  function validates that the combination is a real calendar date.
 - `fn:date:to_string(Date)` converts a `/date` constant back into its ISO-8601
   string form.
 

--- a/docs/spec_datamodel.md
+++ b/docs/spec_datamodel.md
@@ -69,9 +69,10 @@ time zones.
 Dates are commonly constructed with the built-ins described in
 [`spec_builtin_operations.md`](spec_builtin_operations.md):
 
-- `fn:date:from_string("2023-10-06")` parses ISO-8601 strings.
-- `fn:date:from_parts(2023, 10, 6)` creates a date from its numeric
-  year/month/day components.
+- `fn:date("2023-10-06")` or `fn:date:from_string("2023-10-06")` parses
+  ISO-8601 strings.
+- `fn:date(2023, 10, 6)` or `fn:date:from_parts(2023, 10, 6)` creates a date
+  from its numeric year/month/day components.
 - `fn:date:to_string(@2023-10-06)` returns the ISO representation as a string.
 
 The resulting constants can be stored in facts, compared for equality, and used

--- a/functional/functional.go
+++ b/functional/functional.go
@@ -336,6 +336,40 @@ func EvalApplyFn(applyFn ast.ApplyFn, subst ast.Subst) (ast.Constant, error) {
 
 		return ast.String(val.Symbol), nil
 
+	case symbols.Date.Symbol:
+		switch len(evaluatedArgs) {
+		case 1:
+			val := evaluatedArgs[0]
+			if val.Type != ast.StringType {
+				return ast.Constant{}, fmt.Errorf("cannot convert to date: fn:date() expects ast.StringType type when called with 1 argument")
+			}
+			parsed, err := ast.ParseDate(val.Symbol)
+			if err != nil {
+				return ast.Constant{}, err
+			}
+			return parsed, nil
+		case 3:
+			year, err := evaluatedArgs[0].NumberValue()
+			if err != nil {
+				return ast.Constant{}, err
+			}
+			month, err := evaluatedArgs[1].NumberValue()
+			if err != nil {
+				return ast.Constant{}, err
+			}
+			day, err := evaluatedArgs[2].NumberValue()
+			if err != nil {
+				return ast.Constant{}, err
+			}
+			date, err := ast.DateFromParts(int(year), int(month), int(day))
+			if err != nil {
+				return ast.Constant{}, err
+			}
+			return date, nil
+		default:
+			return ast.Constant{}, fmt.Errorf("fn:date() expects 1 or 3 arguments, got %d argument(s)", len(evaluatedArgs))
+		}
+
 	case symbols.DateFromString.Symbol:
 		if l := len(evaluatedArgs); l != 1 {
 			return ast.Constant{}, fmt.Errorf("expected 1 argument, got %d argument(s)", l)

--- a/functional/functional_test.go
+++ b/functional/functional_test.go
@@ -52,9 +52,14 @@ func TestDateFunctions(t *testing.T) {
 		want ast.Constant
 	}{
 		{ast.ApplyFn{symbols.DateFromString, []ast.BaseTerm{ast.String("2023-10-06")}}, dateConst("2023-10-06")},
+		{ast.ApplyFn{symbols.Date, []ast.BaseTerm{ast.String("2023-10-06")}}, dateConst("2023-10-06")},
 		{ast.ApplyFn{symbols.DateToString, []ast.BaseTerm{dateConst("2023-10-06")}}, ast.String("2023-10-06")},
 		{
 			ast.ApplyFn{symbols.DateFromParts, []ast.BaseTerm{ast.Number(2023), ast.Number(10), ast.Number(6)}},
+			dateConst("2023-10-06"),
+		},
+		{
+			ast.ApplyFn{symbols.DateParts, []ast.BaseTerm{ast.Number(2023), ast.Number(10), ast.Number(6)}},
 			dateConst("2023-10-06"),
 		},
 		{
@@ -89,6 +94,15 @@ func TestDateFunctions(t *testing.T) {
 	}
 	if _, err := EvalExpr(ast.ApplyFn{symbols.DateAddDays, []ast.BaseTerm{ast.String("not-a-date"), ast.Number(1)}}, ast.ConstSubstMap{}); err == nil {
 		t.Fatalf("EvalExpr date add days accepted invalid input")
+	}
+	if _, err := EvalExpr(ast.ApplyFn{symbols.Date, []ast.BaseTerm{}}, ast.ConstSubstMap{}); err == nil {
+		t.Fatalf("EvalExpr fn:date accepted wrong arity")
+	}
+	if _, err := EvalExpr(ast.ApplyFn{symbols.Date, []ast.BaseTerm{ast.Number(2023)}}, ast.ConstSubstMap{}); err == nil {
+		t.Fatalf("EvalExpr fn:date accepted non-string input")
+	}
+	if _, err := EvalExpr(ast.ApplyFn{symbols.DateParts, []ast.BaseTerm{ast.Number(2023), ast.Number(10)}}, ast.ConstSubstMap{}); err == nil {
+		t.Fatalf("EvalExpr fn:date/3 accepted wrong arity")
 	}
 }
 

--- a/symbols/symbols.go
+++ b/symbols/symbols.go
@@ -163,6 +163,10 @@ var (
 	Float64ToString = ast.FunctionSym{"fn:float64:to_string", 1}
 	// NameToString converts from ast.NameType to ast.StringType
 	NameToString = ast.FunctionSym{"fn:name:to_string", 1}
+	// Date is an alias for parsing ISO-8601 strings.
+	Date = ast.FunctionSym{"fn:date", 1}
+	// DateParts is an alias for constructing a date from its components.
+	DateParts = ast.FunctionSym{"fn:date", 3}
 	// DateFromString converts from string to date.
 	DateFromString = ast.FunctionSym{"fn:date:from_string", 1}
 	// DateToString converts a date into its ISO-8601 representation.


### PR DESCRIPTION
## Summary
- add support for the `fn:date` alias in the symbol table and builtin registry so both the one- and three-argument forms are recognized
- route `fn:date` calls through the existing date helpers while validating arity and type errors in the functional evaluator
- document the alias in the spec and extend interpreter tests to cover both arities and error paths

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd9db104c88322ad517a30bbcd63b7